### PR TITLE
Update plexWatch.xml

### DIFF
--- a/needo/plexWatch.xml
+++ b/needo/plexWatch.xml
@@ -46,6 +46,6 @@
     </Volume>
   </Data>
   <WebUI>http://[IP]:[PORT:8080]/plexWatch</WebUI>
-  <Banner>http://i.imgur.com/aXdzX1v.png</Banner>
-  <Icon>http://i.imgur.com/aXdzX1v.png</Icon>
+  <Banner>http://i.imgur.com/QkAUWqZ.png</Banner>
+  <Icon>http://i.imgur.com/QkAUWqZ.png</Icon>
 </Container>


### PR DESCRIPTION
Banner and Icon are for PlexConnect, not PlexWatch.  New PNG proposed.