### PR TITLE
Adjust template for ownCloud for DEFAULT_PORT variable.

### DIFF
--- a/gfjardim/ownCloud.xml
+++ b/gfjardim/ownCloud.xml
@@ -31,6 +31,10 @@
       <Name>EDGE</Name>
       <Value>0</Value>
     </Variable>
+    <Variable>
+      <Name>DEFAULT_PORT</Name>
+      <Value>8000</Value>
+    </Variable>
   </Environment>
   <Data>
     <Volume>


### PR DESCRIPTION
Added a new environment variable called DEFAULT_PORT who's default value is of 8000. This will work in conjunction with the edit made to install.sh of owncloud, so that port is adjustable by the end user.