### PR TITLE
Update to CP 4.4.1

### DIFF
--- a/crashplan-desktop/install.sh
+++ b/crashplan-desktop/install.sh
@@ -229,10 +229,10 @@ RUNLVLDIR=/etc/rc${RUNLEVEL}.d
 JAVACOMMON=`which java`
 
 # Downloading Crashplan
-wget -nv https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_4.3.0_Linux.tgz -O - | tar -zx -C /tmp
+wget -nv https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_4.4.1_Linux.tgz -O - | tar -zx -C /tmp
 
 # Installation directory
-cd /tmp/CrashPlan-install
+cd /tmp/crashplan-install
 INSTALL_DIR=`pwd`
 
 # Make the destination dir


### PR DESCRIPTION
These changes install CP 4.4.1 in the Crashplan Desktop container.

We also need to modify the IP address in .ui_info:
  sed -i -e "s|0.0.0.0|172.17.42.1|" /var/lib/crashplan/.ui_info
Maybe it would be better to do this in the main Crashplan docker rather than this one?